### PR TITLE
Fixes github auth for users, closes #673

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def github
     user = User.find_or_create_for_github_oauth(request.env['omniauth.auth'])
 
-    if user.just_created?
+    if user.just_created? || !user.valid? || user.github_import
       sign_in user
       redirect_to edit_user_path(user, welcome: true)
     elsif user.persisted?

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -10,7 +10,7 @@ class RolesController < ApplicationController
   end
 
   def create
-    @role.user = User.where(github_handle: params[:role][:github_handle]).first_or_create
+    @role.user = User.find_or_initialize_by(github_handle: params[:role][:github_handle])
     @role.user.github_import = true
 
     respond_to do |format|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,15 +50,16 @@ class UsersController < ApplicationController
   def update
     respond_to do |format|
       if @user.update_attributes(user_params)
-        notice = 'User was successfully updated.'
+        notice = nil
         # We disabled the confirmation instruction sending in the omniauth
         # user creation and have to do it manually here. If the user
         # decides to change the email address in the form, devise is sending
         # an email confirm message automatically. Otherwise we will sent it
         # manually here
         if !@user.confirmed? && !@user.previous_changes["unconfirmed_email"].present?
-          notice = 'Please click on the link in the email we just sent to confirm your email address.'
           @user.send_confirmation_instructions
+        else
+          notice = 'User was successfully updated.'
         end
         format.html { redirect_to params[:redirect_to] || @user, notice: notice }
         format.json { head :no_content }
@@ -85,6 +86,11 @@ class UsersController < ApplicationController
   def stop_impersonating
     stop_impersonating_user
     redirect_to users_path, notice: "Impersonation stopped. You're back to being #{current_user.name}!"
+  end
+
+  def resend_confirmation_instruction
+    @user.send_confirmation_instructions
+    redirect_back fallback_location: root_path
   end
 
   private

--- a/app/helpers/authentication/active_record_helpers.rb
+++ b/app/helpers/authentication/active_record_helpers.rb
@@ -6,25 +6,33 @@ module Authentication
 
     module ClassMethods
       def find_or_create_for_github_oauth(auth)
-        find_for_github_oauth(auth) || create_for_github_oauth(auth)
+        find_and_update_for_github_oauth(auth) || create_for_github_oauth(auth)
+      end
+
+      def find_and_update_for_github_oauth(auth)
+        user = find_for_github_oauth(auth)
+        update_user(user, auth) if user && user.email.nil? && user.unconfirmed_email.nil?
+        user
       end
 
       def find_for_github_oauth(auth)
-        where(github_id: auth.uid.to_s).first ||
-          where("github_handle ILIKE ?", auth.extra.raw_info.login).first
+        find_by(github_id: auth.uid.to_s) ||
+          find_by("github_handle ILIKE ?", auth.extra.raw_info.login)
       end
 
       def create_for_github_oauth(auth)
-        user = new(
-          avatar_url:    auth.extra.raw_info.avatar_url,
-          name:          auth.info.name,
-          email:         auth.info.email,
-          homepage:      github_homepage(auth),
-          location:      auth.extra.raw_info.location,
-          bio:           auth.extra.raw_info.bio,
-          github_import: true
-        )
-        user.github_id = auth.uid
+        update_user(new(), auth)
+      end
+
+      def update_user(user, auth)
+        user.avatar_url    = auth.extra.raw_info.avatar_url
+        user.name          = auth.info.name
+        user.email         = auth.info.email
+        user.homepage      = github_homepage(auth)
+        user.location      = auth.extra.raw_info.location
+        user.bio           = auth.extra.raw_info.bio
+        user.github_import = true
+        user.github_id     = auth.uid
         user.github_handle = auth.extra.raw_info.login
         user.skip_confirmation_notification!
         user.save!
@@ -32,6 +40,7 @@ module Authentication
       end
 
       private
+
       def github_homepage(auth)
         homepage = auth.extra.raw_info.blog
         if homepage.present? && !homepage.match(User::URL_PREFIX_PATTERN)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,6 +11,8 @@ class Ability
 
     can :crud, User, id: user.id
     can :crud, User if user.admin?
+    can :resend_confirmation_instruction, User, id: user.id
+    can :resend_confirmation_instruction, User if user.admin?
 
     can :crud, Team do |team|
       user.admin? or signed_in?(user) && team.new_record? or on_team?(user, team)

--- a/app/models/concerns/github_handle.rb
+++ b/app/models/concerns/github_handle.rb
@@ -6,7 +6,7 @@ module GithubHandle
   end
 
   def github_handle=(github_handle)
-    self.user = github_handle.present? && User.where(github_handle: github_handle).first || build_user
+    self.user = github_handle.present? && User.find_or_initialize_by(github_handle: github_handle)
     user.github_handle = github_handle
     user.github_import = true
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,7 +108,14 @@ class User < ActiveRecord::Base
   # This field is used to skip validations when creating
   # a preliminary user, e.g. when adding a non existant person
   # to a team using the github handle.
-  attr_accessor :github_import
+  attr_reader :github_import
+
+  # This informs devise that this user does not
+  # need a confirmation notification for now
+  def github_import=(import)
+    @github_import = import
+    skip_confirmation_notification! if @github_import
+  end
 
   class << self
     def ordered(order = nil, direction = 'asc')

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -16,9 +16,9 @@ html
 
   body class=controller.controller_name
     = render 'navigation'
-    
+
     a.ribbon href='//github.com/rails-girls-summer-of-code/rgsoc-teams' title='Fork me on GitHub'
-      
+
     div#wrap
       section.container#content
         div.row
@@ -31,9 +31,14 @@ html
               p.alert.alert-danger
                 button.close data-dismiss="alert" type="button"  &times;
                 = alert
-    
+            - if current_user && !current_user.confirmed? && !params['welcome']
+              p.alert.alert-warning
+                button.close data-dismiss="alert" type="button"  &times;
+                span> Please click on the link in the email we just sent to confirm your email address. Haven't received it?
+                = link_to 'Click here to resend the email.', resend_confirmation_instruction_user_path(current_user), method: :post
+
         = yield
-    
+
     section.container#footer
       footer.footer
         ul

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,9 @@ RgsocTeams::Application.routes.draw do
   end
 
   get 'users/info', to: 'users_info#index'
-  resources :users, except: :new, concerns: [:has_roles, :impersonatable]
+  resources :users, except: :new, concerns: [:has_roles, :impersonatable] do
+    post 'resend_confirmation_instruction', on: :member
+  end
   resources :sources, only: :index
   resources :comments, only: :create
   resources :conferences
@@ -43,8 +45,6 @@ RgsocTeams::Application.routes.draw do
       resources :comments, only: [:create]
       resources :applications, only: [:show, :edit, :update]
     end
-
-
 
     resources :applications, except: [:new, :create, :destroy]
     resources :ratings, only: [:create, :update]

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -11,7 +11,57 @@ describe OmniauthCallbacksController do
       @request.env["omniauth.auth"] = OmniAuth::AuthHash.new(
         uid: '123', provider: 'example',
         info: { name: 'Name', email: 'name@example.com' },
-        extra: { raw_info: { 
+        extra: { raw_info: {
+          avatar_url: 'http://example.com/avatar.png',
+          location:   'Location',
+          bio:        'example user',
+          login:      'example_user'
+        }}
+      )
+      expect {
+        post :github, format: :json
+      }.not_to change { ActionMailer::Base.deliveries.count }
+      expect(response).to redirect_to(edit_user_path(User.last, welcome: true))
+    end
+
+    # If you add a team member using it's github handle, the
+    # user is ceated, but will be empty. If that users then
+    # registers, we need to show the edit page
+    it 'fills a stubbed used and redirects to the user edit page' do
+      user = User.new
+      user.github_handle = 'example_user'
+      user.github_import = true
+      user.save!
+
+      @request.env["omniauth.auth"] = OmniAuth::AuthHash.new(
+        uid: 123, provider: 'example',
+        info: { name: 'Name', email: 'name@example.com' },
+        extra: { raw_info: {
+          avatar_url: 'http://example.com/avatar.png',
+          location:   'Location',
+          bio:        'example user',
+          login:      'example_user'
+        }}
+      )
+      expect {
+        post :github, format: :json
+      }.not_to change { ActionMailer::Base.deliveries.count }
+      expect(response).to redirect_to(edit_user_path(User.last, welcome: true))
+      expect(user.reload.avatar_url).to eql 'http://example.com/avatar.png'
+    end
+
+    # If a user cancels the welcome page and then later signs
+    # in again, we want to show that user the edit page to
+    # let her/him complete the registration
+    it 'redirects to the edit page if the profile is not valid' do
+      user = FactoryGirl.build(:user, country: nil)
+      user.github_import = true
+      user.save
+
+      @request.env["omniauth.auth"] = OmniAuth::AuthHash.new(
+        uid: 123, provider: 'example',
+        info: { name: 'Name', email: 'name@example.com' },
+        extra: { raw_info: {
           avatar_url: 'http://example.com/avatar.png',
           location:   'Location',
           bio:        'example user',
@@ -29,7 +79,7 @@ describe OmniauthCallbacksController do
       @request.env["omniauth.auth"] = OmniAuth::AuthHash.new(
         uid: '123', provider: 'example',
         info: { name: 'Name', email: 'name@example.com' },
-        extra: { raw_info: { 
+        extra: { raw_info: {
           avatar_url: 'http://example.com/avatar.png',
           location:   'Location',
           bio:        'example user',

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -298,4 +298,16 @@ RSpec.describe UsersController do
       expect(flash[:notice]).to include "Impersonation stopped"
     end
   end
+
+  describe 'POST resend_confirmation_instruction' do
+    let(:user) { create(:user) }
+    before do
+      sign_in user
+    end
+
+    it 'resends the confirmation instruction' do
+      expect_any_instance_of(User).to receive :send_confirmation_instructions
+      post :resend_confirmation_instruction, params: { id: user.id }
+    end
+  end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -11,6 +11,8 @@ describe Ability do
       describe 'she/he is allowed to do everything on her/his account' do
         it { expect(ability).to be_able_to(:show, user) }
         it { expect(ability).not_to be_able_to(:create, User.new) } #this only happens through GitHub
+
+        it { expect(ability).to be_able_to(:resend_confirmation_instruction, user) }
       end
 
       context 'when a user is admin' do
@@ -24,6 +26,21 @@ describe Ability do
         let(:other_user) { FactoryGirl.create(:user) }
         it { expect(ability).not_to be_able_to(:show, other_user) }
       end
+
+      context 'resend_confirmation_instruction' do
+        let(:other_user) { FactoryGirl.create(:user) }
+
+        describe 'a user can only resend her/his own confirmation' do
+          it { expect(ability).to be_able_to(:resend_confirmation_instruction, user) }
+          it { expect(ability).not_to be_able_to(:resend_confirmation_instruction, other_user) }
+        end
+
+        describe 'a admin can resend all confirmation tokens' do
+          let!(:organizer_role) { FactoryGirl.create(:organizer_role, user: user) }
+          it { expect(ability).to be_able_to(:resend_confirmation_instruction, other_user) }
+        end
+      end
+
 
       describe 'a user should not be able to mark another\'s attendance to a conference' do
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,6 +31,15 @@ describe User do
     it { expect(subject).not_to validate_presence_of(:email) }
     it { expect(subject).not_to validate_presence_of(:country) }
     it { expect(subject).not_to validate_presence_of(:location) }
+
+    it 'should not send a confirmation email' do
+      expect {
+        subject.github_handle = "example"
+        subject.github_import = true
+        subject.save!
+      }.not_to change { ActionMailer::Base.deliveries.count }
+      subject.reload
+    end
   end
 
   describe 'immutable github handle validation' do


### PR DESCRIPTION
Okay, this changes a few things in the OmniAuth flow.

It will redirect the user to the profile edit page when

* the user is freshly imported from github
* the user is not valid because data is missing

Additionally it shows a warning box if you haven't confirmed
your account yet with a button to confirm it manually.